### PR TITLE
Update SMART Health IT section with updated instructions

### DIFF
--- a/source/example-smart-app/health.html
+++ b/source/example-smart-app/health.html
@@ -1,15 +1,22 @@
 <!DOCTYPE html>
-<html lang="en" hidden>
+<html lang="en">
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <title>Example-SMART-App</title>
-    <link rel='stylesheet' type='text/css' href='./lib/css/cerner-smart-embeddable-lib-1.0.0.min.css'>
+
+    <!--
+      Temporarily disable cerner-smart-embeddable-lib
+      <link rel='stylesheet' type='text/css' href='./lib/css/cerner-smart-embeddable-lib-1.0.0.min.css'>
+    -->
   </head>
   <body>
     <!-- Required JS files to enable this page to embed within an MPage -->
-    <script src='https://cdnjs.cloudflare.com/ajax/libs/babel-polyfill/6.26.0/polyfill.min.js'></script>
-    <script src='./lib/js/cerner-smart-embeddable-lib-1.0.0.min.js'></script>
+    <!--
+      Temporarily disable cerner-smart-embeddable-lib
+      <script src='https://cdnjs.cloudflare.com/ajax/libs/babel-polyfill/6.26.0/polyfill.min.js'></script>
+      <script src='./lib/js/cerner-smart-embeddable-lib-1.0.0.min.js'></script>
+    -->
 
     <img src="./src/images/batman.gif" alt="Batman">
     <p>Healthy!</p>

--- a/source/example-smart-app/index.html
+++ b/source/example-smart-app/index.html
@@ -1,12 +1,15 @@
 <!DOCTYPE html>
-<html lang="en" hidden>
+<html lang="en">
   <head>
     <meta http-equiv='X-UA-Compatible' content='IE=edge' />
     <meta http-equiv='Content-Type' content='text/html; charset=utf-8' />
     <title>Example-SMART-App</title>
 
     <link rel='stylesheet' type='text/css' href='./src/css/example-smart-app.css'>
-    <link rel='stylesheet' type='text/css' href='./lib/css/cerner-smart-embeddable-lib-1.0.0.min.css'>
+    <!--
+      Temporarily disable cerner-smart-embeddable-lib
+      <link rel='stylesheet' type='text/css' href='./lib/css/cerner-smart-embeddable-lib-1.0.0.min.css'>
+    -->
   </head>
   <body>
     <div id='errors'>
@@ -68,8 +71,11 @@
       </table>
     </div>
     <!-- Required JS files to enable this page to embed within an MPage -->
-    <script src='https://cdnjs.cloudflare.com/ajax/libs/babel-polyfill/6.26.0/polyfill.min.js'></script>
-    <script src='./lib/js/cerner-smart-embeddable-lib-1.0.0.min.js'></script>
+    <!--
+      Temporarily disable cerner-smart-embeddable-lib
+      <script src='https://cdnjs.cloudflare.com/ajax/libs/babel-polyfill/6.26.0/polyfill.min.js'></script>
+      <script src='./lib/js/cerner-smart-embeddable-lib-1.0.0.min.js'></script>
+    -->
 
     <!-- Application-level javascript-->
     <script src='./src/js/example-smart-app.js'></script>

--- a/source/example-smart-app/launch-patient.html
+++ b/source/example-smart-app/launch-patient.html
@@ -1,16 +1,22 @@
 <!DOCTYPE html>
-<html lang="en" hidden>
+<html lang="en">
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <link rel='stylesheet' type='text/css' href='./src/css/example-smart-app.css'>
-    <link rel='stylesheet' type='text/css' href='./lib/css/cerner-smart-embeddable-lib-1.0.0.min.css'>
+    <!--
+      Temporarily disable cerner-smart-embeddable-lib
+      <link rel='stylesheet' type='text/css' href='./lib/css/cerner-smart-embeddable-lib-1.0.0.min.css'>
+    -->
     <title>Example-SMART-App</title>
   </head>
   <body>
     <!-- Required JS files to enable this page to embed within an MPage -->
-    <script src='https://cdnjs.cloudflare.com/ajax/libs/babel-polyfill/6.26.0/polyfill.min.js'></script>
-    <script src='./lib/js/cerner-smart-embeddable-lib-1.0.0.min.js'></script>
+    <!--
+      Temporarily disable cerner-smart-embeddable-lib
+      <script src='https://cdnjs.cloudflare.com/ajax/libs/babel-polyfill/6.26.0/polyfill.min.js'></script>
+      <script src='./lib/js/cerner-smart-embeddable-lib-1.0.0.min.js'></script>
+    -->
 
     <!-- FHIR Client JS Library -->
     <script src='./lib/js/fhir-client-v0.1.12.js'></script>

--- a/source/example-smart-app/launch-smart-sandbox.html
+++ b/source/example-smart-app/launch-smart-sandbox.html
@@ -1,16 +1,22 @@
 <!DOCTYPE html>
-<html lang="en" hidden>
+<html lang="en">
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <link rel='stylesheet' type='text/css' href='./src/css/example-smart-app.css'>
-    <link rel='stylesheet' type='text/css' href='./lib/css/cerner-smart-embeddable-lib-1.0.0.min.css'>
+    <!--
+      Temporarily disable cerner-smart-embeddable-lib
+      <link rel='stylesheet' type='text/css' href='./lib/css/cerner-smart-embeddable-lib-1.0.0.min.css'>
+    -->
     <title>Example-SMART-App</title>
   </head>
   <body>
     <!-- Required JS files to enable this page to embed within an MPage -->
-    <script src='https://cdnjs.cloudflare.com/ajax/libs/babel-polyfill/6.26.0/polyfill.min.js'></script>
-    <script src='./lib/js/cerner-smart-embeddable-lib-1.0.0.min.js'></script>
+    <!--
+      Temporarily disable cerner-smart-embeddable-lib
+      <script src='https://cdnjs.cloudflare.com/ajax/libs/babel-polyfill/6.26.0/polyfill.min.js'></script>
+      <script src='./lib/js/cerner-smart-embeddable-lib-1.0.0.min.js'></script>
+    -->
 
     <!-- FHIR Client JS Library -->
     <script src='./lib/js/fhir-client-v0.1.12.js'></script>
@@ -18,9 +24,12 @@
     <!-- Prevent session bleed caused by single threaded embedded browser and sessionStorage API -->
     <!-- https://github.com/cerner/fhir-client-cerner-additions -->
     <script src='./lib/js/fhir-client-cerner-additions-1.0.0.js'></script>
+
+    <!-- Currently, the SMART App Launcher (https://launch.smarthealthit.org) does not check/validate the client_id field.
+        If/when this changes, or when working with other authorization servers, please update the client_id field here. -->
     <script>
       FHIR.oauth2.authorize({
-        'client_id': '20a81fa7-8662-4ac7-afbf-bcfb167c07cf',
+        'client_id': 'YOUR-SMART-HEALTH-IT-CLIENT-ID-HERE',
         'scope':  'patient/Patient.read patient/Observation.read launch online_access openid profile'
       });
     </script>

--- a/source/example-smart-app/launch-smart-sandbox.html
+++ b/source/example-smart-app/launch-smart-sandbox.html
@@ -20,7 +20,7 @@
     <script src='./lib/js/fhir-client-cerner-additions-1.0.0.js'></script>
     <script>
       FHIR.oauth2.authorize({
-        'client_id': 'YOUR-SMART-HEALTH-IT-CLIENT-ID-HERE',
+        'client_id': '20a81fa7-8662-4ac7-afbf-bcfb167c07cf',
         'scope':  'patient/Patient.read patient/Observation.read launch online_access openid profile'
       });
     </script>

--- a/source/example-smart-app/launch.html
+++ b/source/example-smart-app/launch.html
@@ -1,16 +1,22 @@
 <!DOCTYPE html>
-<html lang="en" hidden>
+<html lang="en">
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <link rel='stylesheet' type='text/css' href='./src/css/example-smart-app.css'>
-    <link rel='stylesheet' type='text/css' href='./lib/css/cerner-smart-embeddable-lib-1.0.0.min.css'>
+    <!--
+      Temporarily disable cerner-smart-embeddable-lib
+      <link rel='stylesheet' type='text/css' href='./lib/css/cerner-smart-embeddable-lib-1.0.0.min.css'>
+    -->
     <title>Example-SMART-App</title>
   </head>
   <body>
     <!-- Required JS files to enable this page to embed within an MPage -->
-    <script src='https://cdnjs.cloudflare.com/ajax/libs/babel-polyfill/6.26.0/polyfill.min.js'></script>
-    <script src='./lib/js/cerner-smart-embeddable-lib-1.0.0.min.js'></script>
+    <!--
+      Temporarily disable cerner-smart-embeddable-lib
+      <script src='https://cdnjs.cloudflare.com/ajax/libs/babel-polyfill/6.26.0/polyfill.min.js'></script>
+      <script src='./lib/js/cerner-smart-embeddable-lib-1.0.0.min.js'></script>
+    -->
 
     <!-- FHIR Client JS Library -->
     <script src='./lib/js/fhir-client-v0.1.12.js'></script>

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -511,8 +511,24 @@ One of the reasons why SMART on FHIR is awesome is because of the interoperabili
 * For the purpose of this tutorial we will leave the **Advanced** options as is.
 * In the **Launch** section, use the following value but replace `<gh-username>` with your GitHub username for **App Launch URL**:
 https://`<gh-username>`.github.io/smart-on-fhir-tutorial/example-smart-app/launch-smart-sandbox.html
+* Note: Currently, the [SMART App Launcher](https://launch.smarthealthit.org) does not check/validate the `client_id` field. So, any value for `client_id` is fine. If/when this changes, or when working with other authorization servers, please update the `client_id` field in `launch-smart-sandbox.html` file.
 * Now launch the app by clicking on the green 'Launch App!' button to see your app opened in the simulated EHR with the patient data.
 
+
+> launch-smart-sandbox.html
+
+```
+...
+<!-- Currently, the SMART App Launcher (https://launch.smarthealthit.org) does not check/validate the client_id field.
+        If/when this changes, or when working with other authorization servers, please update the client_id field here. -->
+<script>
+  FHIR.oauth2.authorize({
+    'client_id': 'YOUR-SMART-HEALTH-IT-CLIENT-ID-HERE',
+    'scope':  'patient/Patient.read patient/Observation.read launch online_access openid profile'
+  });
+</script>
+...
+```
 
 # Standalone App Launch for Patient Access Workflow
 

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -499,38 +499,20 @@ description for how to properly size the application, and note additional consid
 Note: The steps above only ensure that the application will meet certain prerequisites to securely embed a SMART app within an MPage® view.
 Once these relevant files and HTML tags are included inside each view of the app, then the application should be ready for SMART in MPage® integration.
 
-# Run your app against SMART Health IT Sandbox
+# Run your app against SMART Health IT
 
-One of the reasons why SMART on FHIR is awesome is because of the interoperability factor!  If an EHR follows the SMART and FHIR specifications, your application will work with that EHR's SMART on FHIR implemenmtation.  Let's see if the app that you've built will work with [SMART Health IT Sandbox](https://sandbox.smarthealthit.org).  The following steps will walk you through setting up your app at SMART Health IT Sandbox.
+One of the reasons why SMART on FHIR is awesome is because of the interoperability factor!  If an EHR follows the SMART and FHIR specifications, your application will work with that EHR's SMART on FHIR implemenmtation.  Let's see if the app that you've built will work with [SMART Launcher](https://launch.smarthealthit.org).  The following steps will walk you through setting up your app at SMART Health IT site.
 
-* Go to [https://sandbox.smarthealthit.org](https://sandbox.smarthealthit.org) (create an account or sign in)
-* Under My Sandboxes, select SMART DSTU2 Sandbox
-* You will come to a list of your Registered Sandbox Apps. There are 3 SMART apps automatically configured on your account (BP Centiles, Cardiac Risk, and Growth Chart).
-* Add your SMART example app by clicking “Register Manually” under the “Registered Sandbox Apps” title
-* You will see a modal popup that allows you to configure your application details, then hit save.
- * Keep the default App Type: Public Client
- * Fill in relevant details just as you did for the Cerner sandbox (App name, redirect URI)
- * For launch URI, use the following value but replace `<gh-username>` with your GitHub username:
-  * ```https://<gh-username>.github.io/smart-on-fhir-tutorial/example-smart-app/launch-smart-sandbox.html```
- * Keep “Allow Offline Access” checkbox unchecked and the Patient Scoped App checked as well (these are defaults)
+* Go to [https://launch.smarthealthit.org](https://launch.smarthealthit.org)
+* In the **App Launch Options** select **Launch Type** as 'Provider EHR Launch' with 'Simulate launch within the EHR user interface' box checked. This is the default.
+* Under **FHIR Version**, select 'R2 (DSTU2)'
+* In the **Patient(s)** section, click the drop down button to open a list of patients in a new pop up window. Select any patient and click 'OK'. This should populate the patient ID in the field.
+* In the **Provider(s)** section, click the drop down button to open a list of providers. Select any provider to populate the Provider ID in the field.
+* For the purpose of this tutorial we will leave the **Advanced** options as is.
+* In the **Launch** section, use the following value but replace `<gh-username>` with your GitHub username for **App Launch URL**:
+https://`<gh-username>`.github.io/smart-on-fhir-tutorial/example-smart-app/launch-smart-sandbox.html
+* Now launch the app by clicking on the green 'Launch App!' button to see your app opened in the simulated EHR with the patient data.
 
-> Update client ID in launch-smart-sandbox.html
-
-```
-<script>
-  FHIR.oauth2.authorize({
-    'client_id': 'YOUR-SMART-HEALTH-IT-CLIENT-ID-HERE',
-    'scope':  'patient/Patient.read patient/Observation.read launch online_access openid profile'
-  });
-</script>
-```
-
-* Another modal will appear with your new client ID. Copy this ID and paste it in your `launch-smart-sandbox.html` client ID section (just as you did when you received your Cerner Sandbox client ID). Commit this change in gh-pages branch.
-* In your `launch-smart-sandbox.html`, copy the scopes for your application.
-* In the SMART Health IT Sandbox, you can now “edit” your application under your registered sandbox apps. Click that, then a side menu will appear with the config for the app. Under “Scopes”, paste over your scopes you copied from the `launch-smart-sandbox.html` (overwriting what is default configured for the app).
-* At the top, click “Save” to save your app configuration
-* You can now launch the application by clicking “launch”, and choose a patient in context (some patients with Observations include: [Allen, Carol G. | Adams, Daniel X. | Coleman, Lisa P.])
-* You will be re-directed to the OpenID connect authorization server – similar to the Cerner Millenium login screen. All you have to do is at the bottom of the screen, click “Authorize” when it asks “Do you authorize [insert app name here]”.
 
 # Standalone App Launch for Patient Access Workflow
 


### PR DESCRIPTION
Addressing issue https://github.com/cerner/smart-on-fhir-tutorial/issues/48.  SMART Health IT site updated their Sandbox with the new [SMART Launcher](http://launch.smarthealthit.org/).  This PR is to update the tutorial to reflect this new change.  SMART Health IT site doesn't validate the `client_id` so this can be set to any value.

@zplata 
@kpshek 
@mjhenkes 
