### PR TITLE
master -> main to increase inclusion

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -159,7 +159,7 @@ incremental_deploy() {
     0) echo No changes to files in $deploy_directory. Skipping commit.;;
     1) commit+push;;
     *)
-      echo git diff exited with code $diff. Aborting. Staying on branch $deploy_branch so you can debug. To switch back to master, use: git symbolic-ref HEAD refs/heads/master && git reset --mixed >&2
+      echo git diff exited with code $diff. Aborting. Staying on branch $deploy_branch so you can debug. To switch back to main, use: git symbolic-ref HEAD refs/heads/main && git reset --mixed >&2
       return $diff
       ;;
   esac


### PR DESCRIPTION
After merging this change in, I will also be renaming the master branch to 'main'. I don't believe we have any CI/secondary systems which refer to 'master' so this change shouldn't cause any disruptions.